### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Welcome to LaraWebEd! - A CMS build on Laravel
 ===================
 
-#Try WebEd CMS version 3 at:
+# Try WebEd CMS version 3 at:
 [https://github.com/sgsoft-studio/webed](https://github.com/sgsoft-studio/webed)
 
-###A starter CMS for Laravel
+### A starter CMS for Laravel
 I have write a CMS for this framework, Support multi language.
 I'm writing some other feature: ecommerce, manage orders, checkout...
 I hope it can helps you more for start a new project.
@@ -13,9 +13,9 @@ If you need more support, please feel free to contact me via:
 - Skype: tedozi.manson
 - Email: duyphan.developer@gmail.com
 
-###LaraWebEd is always free.
+### LaraWebEd is always free.
 
-###Some features of this CMS:
+### Some features of this CMS:
 - Manage page, post, product, category, product category.
 - Manage file by el-finder.
 - Manage page template.
@@ -91,7 +91,7 @@ On this projects, I use the latest Laravel version (currently 5.2). Please go to
 
 > RECAPTCHA_SECRET_KEY=6Lfy4hYTAAAAAGTRaZggVzW_PAyVxmGguw8uSWyH
 
-####Note
+#### Note
 - This site can only be run at domain name, not folder link.
 - On your localhost, setting virtual host. Something like 
 
@@ -110,9 +110,9 @@ Well done! Now, you can login to the dashboard by access to [your_domain_site/ad
 
 Enjoy!
 
-#####Star for me if this cms helps you a lot!
+##### Star for me if this cms helps you a lot!
 
-###Table of contents
+### Table of contents
 
 - [Custom fields](./documentation/CustomFields.md)
 - [Page template](./documentation/PageTemplate.md)

--- a/documentation/CustomFields.md
+++ b/documentation/CustomFields.md
@@ -5,29 +5,29 @@ This guide show you how to create custom fields (for page, post, product, catego
 
 ----------
 
-####Register custom fields:
+#### Register custom fields:
 --------
 [How to create custom fields in LaraWebEd](https://www.youtube.com/watch?v=8ku2yaByYMI)
 
-####Access custom fields:
+#### Access custom fields:
 --------
 
 You can access the custom fields from both controllers and views via:
 
-#####Front controllers:
+##### Front controllers:
 In the front controller of Page, Post, Category, Product, Product Category, you have the method **_defaultItem()** and **other page template methods**. You can access all the custom fields of these items by:
 
 ````code
 $this->dis['currentObjectCustomFields']
 ````
 
-#####Front views:
+##### Front views:
 
 ````code
 $currentObjectCustomFields
 ````
 
-####The helpers for custom fields
+#### The helpers for custom fields
 
 - Get field: get a field value by field name: **_getField**
 

--- a/public/third_party/notific8/CHANGELOG.md
+++ b/public/third_party/notific8/CHANGELOG.md
@@ -1,4 +1,4 @@
-#Change Log
+# Change Log
 
 The change log was created with version 2.0. For changes, please see the commit history of the project.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
